### PR TITLE
EC：バグ修正：管理画面・住所一覧

### DIFF
--- a/laracom/project/resources/views/admin/addresses/list.blade.php
+++ b/laracom/project/resources/views/admin/addresses/list.blade.php
@@ -26,7 +26,7 @@
                         <tbody>
                         @foreach ($addresses as $address)
                             <tr>
-                                <td><a href="{{ route('admin.customers.show', [$address->customer_id]) }}">{{ $address->alias }}</a></td>
+                                <td><a href="{{ route('admin.addresses.show', [$address->id]) }}">{{ $address->alias }}</a></td>
                                 <td>{{ $address->address_1 }}</td>
                                 <td>{{ $address->country }}</td>
                                 <td>{{ $address->province }}</td>


### PR DESCRIPTION
### EC：バグ修正：管理画面・住所一覧
**概要**
`http://localhost:8000/admin/addresses`
にアクセスすると発生する下記のエラーを解除する

![image](https://github.com/MikuHashimoto/lxp-practical-project/assets/134348174/8f65f66d-9b5a-49a4-bd30-bcc10e0a0048)


**方針**
`laracom/project/resources/views/admin/addresses/list.blade.php`においてadmin.customers.showに適切なパラメーターが不足していることから、適切なパラメーターを渡すように該当箇所を修正
また、パラメーター名の変更に対してroute名も違和感のないように修正
`laracom/project/resources/views/admin/addresses/list.blade.php`の29行目にて下記の2つを修正

```
customer_id→id
admin.customers.show→admin.addresses.show
```

**修正前**
![image](https://github.com/MikuHashimoto/lxp-practical-project/assets/134348174/9fad4b47-f4ff-463f-b5f0-85e4dada4a1e)

**修正後**
![image](https://github.com/MikuHashimoto/lxp-practical-project/assets/134348174/b050088f-554f-4d02-843d-1c22ffd65d90)
